### PR TITLE
Bugfix for symlink issue #13

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/jar/Jar.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/jar/Jar.java
@@ -87,6 +87,8 @@ public class Jar extends TakariLifecycleMojo {
         if (classesDirectory.isDirectory()) {
           Iterable<File> inputs = registeredOutput.addInputs(classesDirectory, null, null);
           logger.debug("Analyzing main classes directory {} with {} entries", classesDirectory, size(inputs));
+          for (File input : inputs)
+            logger.debug("  Entry: {}", input);
         } else {
           logger.warn("Main classes directory {} does not exist", classesDirectory);
         }
@@ -204,8 +206,11 @@ public class Jar extends TakariLifecycleMojo {
 
   private List<Entry> inputsSource(File basedir, Iterable<File> inputs) {
     final List<Entry> entries = new ArrayList<>();
+    logger.debug("inputsSource - basedir {}", basedir);
     for (File input : inputs) {
       String entryName = getRelativePath(basedir, input);
+      logger.debug("  inputsSource - input {}", input);
+      logger.debug("  inputsSource - adding entry {}", entryName);
       entries.add(new FileEntry(entryName, input));
     }
     return entries;

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/jar/Jar.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/jar/Jar.java
@@ -192,11 +192,16 @@ public class Jar extends TakariLifecycleMojo {
     }
   }
 
-  static String getRelativePath(File basedir, File resource) {
-    return basedir.toPath().relativize(resource.toPath()).toString().replace('\\', '/'); // always use forward slash for path separator
+  static String getRelativePath(File basedir, File resource) throws IOException {
+    return basedir
+      .getCanonicalFile()
+      .toPath()
+      .relativize(resource.getCanonicalFile().toPath())
+      .toString()
+      .replace('\\', '/'); // always use forward slash for path separator
   }
 
-  private List<Entry> inputsSource(Multimap<File, File> inputs) {
+  private List<Entry> inputsSource(Multimap<File, File> inputs) throws IOException {
     final List<Entry> entries = new ArrayList<>();
     for (File basedir : inputs.keySet()) {
       entries.addAll(inputsSource(basedir, inputs.get(basedir)));
@@ -204,7 +209,7 @@ public class Jar extends TakariLifecycleMojo {
     return entries;
   }
 
-  private List<Entry> inputsSource(File basedir, Iterable<File> inputs) {
+  private List<Entry> inputsSource(File basedir, Iterable<File> inputs) throws IOException {
     final List<Entry> entries = new ArrayList<>();
     logger.debug("inputsSource - basedir {}", basedir);
     for (File input : inputs) {


### PR DESCRIPTION
This fixes a problem which was not present in 1.10.3, but since 1.11.3 on UNIXoid systems, the symptom of which is a failing dependent module build because dependency Takari JARs did not contain any class files.