### PR TITLE
support -parameters option of javac

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/AbstractCompileMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/AbstractCompileMojo.java
@@ -170,6 +170,14 @@ public abstract class AbstractCompileMojo extends AbstractMojo {
   private boolean verbose;
 
   /**
+   * Set to <code>true</code> to store formal parameter names of constructors and methods in the generated class file 
+   * so that the method <code>java.lang.reflect.Executable.getParameters</code> from the Reflection API can retrieve them.
+   * Valid only when javac is used.
+   */
+  @Parameter(defaultValue = "false")
+  private boolean parameters;
+
+  /**
    * Sets whether generated class files include debug information or not.
    * <p>
    * Allowed values
@@ -361,6 +369,7 @@ public abstract class AbstractCompileMojo extends AbstractMojo {
       compiler.setAnnotationProcessors(annotationProcessors);
       compiler.setAnnotationProcessorOptions(annotationProcessorOptions);
       compiler.setVerbose(verbose);
+	  compiler.setParametersEnabled(parameters);
       compiler.setPom(pom);
       compiler.setSourceEncoding(getSourceEncoding());
       compiler.setDebug(parseDebug(debug));

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/AbstractCompiler.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/AbstractCompiler.java
@@ -43,6 +43,8 @@ public abstract class AbstractCompiler {
 
   private boolean verbose;
 
+  private boolean parametersEnabled;
+
   private File pom;
 
   private Charset sourceEncoding;
@@ -129,6 +131,10 @@ public abstract class AbstractCompiler {
     this.verbose = verbose;
   }
 
+  public void setParametersEnabled(boolean parametersEnabled) {
+    this.parametersEnabled = parametersEnabled;
+  }
+
   public void setPrivatePackageReference(AccessRulesViolation privatePackageReference) {
     this.privatePackageReference = privatePackageReference;
   }
@@ -147,6 +153,10 @@ public abstract class AbstractCompiler {
 
   protected boolean isVerbose() {
     return verbose;
+  }
+
+  protected boolean isParametersEnabled() {
+    return parametersEnabled;
   }
 
   public void setPom(File pom) {

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/javac/AbstractCompilerJavac.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/javac/AbstractCompilerJavac.java
@@ -114,6 +114,9 @@ public abstract class AbstractCompilerJavac extends AbstractCompiler {
     if (isVerbose()) {
       options.add("-verbose");
     }
+    if (isParametersEnabled()) {
+      options.add("-parameters");
+    }
 
     Set<Debug> debug = getDebug();
     if (debug == null || debug.contains(Debug.all)) {


### PR DESCRIPTION
`javac` has `-parameters` option (https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html), which is sometimes required by applications. This pull request adds a new configurable parameter to enable this option.