### PR TITLE
fixed test and provided dependencies leak into 'classpath' test property

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/testproperties/TestPropertiesMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/testproperties/TestPropertiesMojo.java
@@ -34,6 +34,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.m2e.workspace.MutableWorkspaceState;
 
+import com.google.common.collect.ImmutableSet;
+
 import io.takari.incrementalbuild.BasicBuildContext;
 import io.takari.incrementalbuild.Incremental;
 import io.takari.incrementalbuild.Incremental.Configuration;
@@ -166,11 +168,14 @@ public class TestPropertiesMojo extends AbstractMojo {
   }
 
   private String getClasspathString() {
+    Set<String> scopes = ImmutableSet.of(Artifact.SCOPE_COMPILE, Artifact.SCOPE_RUNTIME);
     StringBuilder sb = new StringBuilder();
     sb.append(outputDirectory.getAbsolutePath());
     for (Artifact dependency : dependencies) {
-      sb.append(File.pathSeparatorChar);
-      sb.append(dependency.getFile().getAbsolutePath());
+      if (scopes.contains(dependency.getScope())) {
+        sb.append(File.pathSeparatorChar);
+        sb.append(dependency.getFile().getAbsolutePath());
+      }
     }
     return sb.toString();
   }

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/testproperties/TestPropertiesMojoTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/testproperties/TestPropertiesMojoTest.java
@@ -210,4 +210,21 @@ public class TestPropertiesMojoTest {
     Assert.assertEquals(ga_tests.getCanonicalPath().replace('\\', '/'), properties.get("ga_tests"));
   }
 
+  @Test
+  public void testClasspathScope() throws Exception {
+    File basedir = resources.getBasedir();
+    MavenProject project = mojos.readMavenProject(basedir);
+    MavenSession session = mojos.newMavenSession(project);
+
+    File providedScoped = temp.newFile("provided.jar").getCanonicalFile();
+    File testScoped = temp.newFile("test.jar").getCanonicalFile();
+
+    mojos.newDependency(providedScoped).setGroupId("g").setArtifactId("provided").setScope("provided").addTo(project);
+    mojos.newDependency(testScoped).setGroupId("g").setArtifactId("test").setScope("test").addTo(project);
+
+    mojos.executeMojo(session, project, "testProperties");
+
+    Map<String, String> properties = readProperties(basedir);
+    Assert.assertEquals(new File(basedir, "target/classes").getCanonicalPath(), properties.get("classpath"));
+  }
 }


### PR DESCRIPTION
this is a regression introduced in commit 776174. pretty much broke any
meaningful integration testing of maven core extensions. not sure how I
didn't notice this problem all this time.

Signed-off-by: Igor Fedorenko <igor@ifedorenko.com>