### PR TITLE
TestPropertiesMojo: write settings file location only if the file exists

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/testproperties/TestPropertiesMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/testproperties/TestPropertiesMojo.java
@@ -122,11 +122,15 @@ public class TestPropertiesMojo extends AbstractMojo {
 
       // well-known properties, TODO introduce named constants
       putIfAbsent(properties, "localRepository", localRepository.getBasedir());
-      if (userSettingsFile != null) {
+      if (isAccessible(userSettingsFile)) {
         putIfAbsent(properties, "userSettingsFile", userSettingsFile.getAbsolutePath());
+      } else {
+        logWarningNotAccessibleFile(userSettingsFile);
       }
-      if (globalSettingsFile != null) {
+      if (isAccessible(globalSettingsFile)) {
         putIfAbsent(properties, "globalSettingsFile", globalSettingsFile.getAbsolutePath());
+      } else{
+        logWarningNotAccessibleFile(globalSettingsFile);
       }
       List<ArtifactRepository> repositories = project.getRemoteArtifactRepositories();
       for (int i = 0; i < repositories.size(); i++) {
@@ -262,6 +266,25 @@ public class TestPropertiesMojo extends AbstractMojo {
       return writer.toString();
     } catch (IOException e) {
       return value; // shouldn't happen
+    }
+  }
+
+  private boolean isAccessible(File file) {
+    return file != null && file.isFile() && file.canRead();
+  }
+
+  private void logWarningNotAccessibleFile(File file) {
+    if (file != null) {
+      String msg = "File '" + file.getAbsolutePath() + "' ";
+      if (file.exists() && !file.isFile()) {
+        msg += "exists, but it is not a regular file!";
+      } else if (file.exists() && file.isFile() && !file.canRead()) {
+        msg += "exists, but can not be read!";
+      } else {
+        msg += "does not exist!";
+      }
+      msg += " It will be ignored.";
+      getLog().warn(msg);
     }
   }
 }


### PR DESCRIPTION
 * this was encountered in takari-plugin-testing. In case there is no
   custom settings file provided (-s) and the default one does not exist,
   it would fail as it tries to use the non-existent file which was written
   into test.properties

 * it seems maven will inject the default "~/.m2/settings.xml" location into
   the field, even if the file does not exist.

I would be happy to add a (unit) test, but I am not sure how to do that since this involves messing with `~/.m2/settings.xml`. I guess it should be possibly to write really simple unit test, where I would mock everything and inject invalid userSettingsFile location and checked it does not get written into the test.properties file. Let me know if that would be preferred for you or the PR is ok as it is.

See https://github.com/takari/takari-plugin-testing-project/issues/11 for additional info.