### PR TITLE
Setup authentication for altDeploymentRepository from settings

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/Deploy.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/Deploy.java
@@ -15,11 +15,14 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Server;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.deployment.DeployRequest;
 import org.eclipse.aether.deployment.DeploymentException;
+import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.util.artifact.SubArtifact;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
 
 import io.takari.maven.plugins.util.AetherUtils;
 
@@ -104,10 +107,20 @@ public class Deploy extends TakariLifecycleMojo {
       String url = matcher.group(3).trim();
 
       RemoteRepository.Builder builder = new RemoteRepository.Builder(id, layout, url);
-
+      Server server = settings.getServer(id);
+      if (server != null) {
+        builder.setAuthentication(createAuthentication(server));
+      }
       return builder.build();
     }
 
     return AetherUtils.toRepo(project.getDistributionManagementArtifactRepository());
+  }
+
+  private Authentication createAuthentication(Server server) {
+    AuthenticationBuilder authBuilder = new AuthenticationBuilder();
+    authBuilder.addUsername(server.getUsername()).addPassword(server.getPassword());
+    authBuilder.addPrivateKey(server.getPrivateKey(), server.getPassphrase());
+    return authBuilder.build();
   }
 }


### PR DESCRIPTION
This is needed when deploying alternate remote repository which requires authentication.

It would be nice to add test for this, but I am not sure how to (easily) do that. The test would either need running instance of remote repo with authentication (this looks quite heavy), or I could try to create the Deploy class with mocks and just check the method `remoteRepository` takes the config from settings xml. Any suggestions welcome.