### PR TITLE
Remove requiresDependencyResolution from sisu-index mojos

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/sisu/SisuIndexMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/sisu/SisuIndexMojo.java
@@ -5,9 +5,8 @@ import java.io.File;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.plugins.annotations.ResolutionScope;
 
-@Mojo(name = "sisu-index", defaultPhase = LifecyclePhase.PROCESS_CLASSES, threadSafe = true, requiresDependencyResolution = ResolutionScope.COMPILE)
+@Mojo(name = "sisu-index", defaultPhase = LifecyclePhase.PROCESS_CLASSES, threadSafe = true)
 public class SisuIndexMojo extends AbstractSisuIndexMojo {
 
   public static final String PATH_SISU_INDEX = "META-INF/sisu/javax.inject.Named";

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/sisu/SisuTestIndexMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/sisu/SisuTestIndexMojo.java
@@ -5,9 +5,8 @@ import java.io.File;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.plugins.annotations.ResolutionScope;
 
-@Mojo(name = "sisu-test-index", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES, threadSafe = true, requiresDependencyResolution = ResolutionScope.TEST)
+@Mojo(name = "sisu-test-index", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES, threadSafe = true)
 public class SisuTestIndexMojo extends AbstractSisuIndexMojo {
 
   public static final String PATH_SISU_INDEX = "META-INF/sisu/javax.inject.Named";


### PR DESCRIPTION
Sisu-index mojos don't seem to be making any use of dependency resolution.