### PR TITLE
shows that FilerImpl has a bug, and the fix.

### DIFF
--- a/takari-lifecycle-plugin-its/src/test/projects/compile-proc/processor/src/main/java/processor/MyAnnotationProcessor.java
+++ b/takari-lifecycle-plugin-its/src/test/projects/compile-proc/processor/src/main/java/processor/MyAnnotationProcessor.java
@@ -9,6 +9,9 @@ package processor;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.util.Set;
 
 import javax.annotation.processing.AbstractProcessor;
@@ -35,17 +38,21 @@ public class MyAnnotationProcessor extends AbstractProcessor {
         String clsQualifiedName = pkg.getQualifiedName() + "." + clsSimpleName;
         JavaFileObject sourceFile =
             processingEnv.getFiler().createSourceFile(clsQualifiedName, element);
-        BufferedWriter w = new BufferedWriter(sourceFile.openWriter());
+        OutputStream ios = sourceFile.openOutputStream();
+        OutputStreamWriter writer = new OutputStreamWriter(ios, "UTF-8");
+        BufferedWriter w = new BufferedWriter(writer);
         try {
           w.append("package ").append(pkg.getQualifiedName()).append(";");
           w.newLine();
           w.append("public class ").append(clsSimpleName).append(" { }");
         } finally {
           w.close();
+          writer.close();
+          ios.close();
         }
       } catch (IOException e) {
         e.printStackTrace();
-      }
+      } 
     }
     return true;
   }

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/jdt/FilerImpl.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/jdt/FilerImpl.java
@@ -130,12 +130,18 @@ class FilerImpl implements Filer {
       throw new FilerException("Attempt to recreate file for type " + name);
     }
     return new JavaFileObjectImpl(sourceFile, new FileObjectDelegate(getInputs(originatingElements)) {
+
+      private boolean closed = false;
+
       @Override
       protected void onClose(Output<File> generatedSource) {
-        // TODO optimize if the regenerated sources didn't change compared the previous build
-        CompilationUnit unit = new CompilationUnit(null, generatedSource.getResource().getAbsolutePath(), null /* encoding */);
-        processingEnv.addNewUnit(unit);
-        incrementalCompiler.addGeneratedSource(generatedSource);
+        if (!closed) {
+          closed = true;
+          // TODO optimize if the regenerated sources didn't change compared the previous build
+          CompilationUnit unit = new CompilationUnit(null, generatedSource.getResource().getAbsolutePath(), null /* encoding */);
+          processingEnv.addNewUnit(unit);
+          incrementalCompiler.addGeneratedSource(generatedSource);
+        }
       }
     });
   }


### PR DESCRIPTION
outputstreams could have been closed multiple times, allowing the same
file object to be added multiple times in jdt.   Javac had it's own
internal check and wasn't effected.