### PR TITLE
Small change to make project IntelliJ Idea friendly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
     <pluginTestingVersion>2.9.0</pluginTestingVersion>
     <takariLifecycleVersion>1.13.0</takariLifecycleVersion>
     <takari.javaSourceVersion>1.8</takari.javaSourceVersion>
+
+    <!-- To make project Idea friendly -->
+    <maven.compiler.source>${takari.javaSourceVersion}</maven.compiler.source>
+    <maven.compiler.target>${takari.javaSourceVersion}</maven.compiler.target>
   </properties>
 
   <scm>


### PR DESCRIPTION
This could be done also in takari parent, to make all Takari projects
Idea friendly.

Without this, Idea applies "default" (Java 7) lang level, as it is unaware of lifecycle (yet).