### PR TITLE
Accommodate an alternate lifecycle producing the primary artifact.

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/TakariLifecycleFlags.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/TakariLifecycleFlags.java
@@ -1,0 +1,5 @@
+package io.takari.maven.plugins;
+
+public interface TakariLifecycleFlags {
+  String ALTERNATE_LIFECYCLE_PROVIDING_PRIMARY_ARTIFACT = "@ALTERNATE_LIFECYCLE_PROVIDING_PRIMARY_ARTIFACT@";
+}

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/TakariLifecycleMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/TakariLifecycleMojo.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -50,6 +51,10 @@ public abstract class TakariLifecycleMojo extends AbstractMojo {
   @Parameter(defaultValue = "${project}", readonly = true)
   @Incremental(configuration = Configuration.ignore)
   protected MavenProject project;
+
+  @Parameter(defaultValue = "${session}")
+  @Incremental(configuration = Configuration.ignore)
+  private MavenSession session;
 
   @Parameter(defaultValue = "${reactorProjects}", readonly = true)
   @Incremental(configuration = Configuration.ignore)
@@ -97,5 +102,13 @@ public abstract class TakariLifecycleMojo extends AbstractMojo {
     }
 
     executeMojo();
+  }
+
+  protected boolean alternateLifecycleProvidingPrimaryArtifact() {
+    String alternateLifecycleProvidingPrimaryArtifact = session.getUserProperties().getProperty(TakariLifecycleFlags.ALTERNATE_LIFECYCLE_PROVIDING_PRIMARY_ARTIFACT);
+    if(alternateLifecycleProvidingPrimaryArtifact != null && alternateLifecycleProvidingPrimaryArtifact.equals("true")) {
+      return true;
+    }
+    return false;
   }
 }

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/TakariLifecycles.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/TakariLifecycles.java
@@ -1,0 +1,24 @@
+package io.takari.maven.plugins;
+
+public enum TakariLifecycles {
+  TAKARI_JAR("takari-jar"),
+  TAKARI_MAVEN_PLUGIN("takari-maven-plugin"),
+  TAKARI_MAVEN_COMPONENT("takari-maven-component"),
+  // while testing we're not setting any specific Takari lifecycle explicitly in our tests so many
+  // of the JAR Mojo tests fail because we now explicitly want one of the Takari lifecycles to make
+  // the JAR produced by the JAR Mojo the primary artifact.
+  TAKARI_TESTING("jar");
+
+  private String lifecycle;
+
+  TakariLifecycles(String lifecycle) {
+    this.lifecycle = lifecycle;
+  }
+
+  public static boolean isJarProducingTakariLifecycle(String lifecycle) {
+    return TAKARI_JAR.lifecycle.equals(lifecycle)
+        || TAKARI_MAVEN_PLUGIN.lifecycle.equals(lifecycle)
+        || TAKARI_MAVEN_COMPONENT.lifecycle.equals(lifecycle)
+        || TAKARI_TESTING.lifecycle.equals(lifecycle);
+  }
+}


### PR DESCRIPTION
Currently during the JAR producing Takari lifecycles (takari-jar, takari-maven-component and takari-maven-plugin) make the reasonable assumption that the Jar Mojo will be producing the primary artifact. This change allows a flag to be set during the build to signal that another Takari-based lifecycle will produce the primary artifact.

In my particular use case I have a "provisio" lifecycle that uses Takari Mojos for standard lifecycle handling but it produces a tar.gz file of a server runtime as the primary artifact. I want the JAR to be an attached artifact and packaged with the server but also deployed separately.

This change should not interfere with any existing cases as in order to trigger this behavior the user has to explicity use a custom lifecycle, and explicity set the flag to take over to role of producing the primary artifact.