### PR TITLE
Update for Java 11

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.0/apache-maven-3.5.0-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>takari</artifactId>
-    <version>27</version>
+    <version>28</version>
   </parent>
 
   <groupId>io.takari.maven.plugins</groupId>
@@ -24,20 +24,21 @@
   <packaging>pom</packaging>
 
   <prerequisites>
-    <maven>[3.2.1,)</maven>
+    <maven>[3.6.3,)</maven>
   </prerequisites>
 
   <properties>
-    <mavenVersion>3.3.1</mavenVersion>
-    <sisuVersion>0.3.0</sisuVersion>
-    <sisuGuiceVersion>3.2.5</sisuGuiceVersion>
-    <aetherVersion>1.0.2.v20150114</aetherVersion>
-    <incrementalbuild.version>0.20.7</incrementalbuild.version>
-    <guava.version>18.0</guava.version>
-    <mavenPluginPluginVersion>3.3</mavenPluginPluginVersion>
+    <mavenVersion>3.6.3</mavenVersion>
+    <sisuVersion>0.3.4</sisuVersion>
+    <sisuGuiceVersion>4.2.0</sisuGuiceVersion>
+    <aetherVersion>1.4.1</aetherVersion>
+    <incrementalbuild.version>0.20.10</incrementalbuild.version>
+    <guava.version>28.2-jre</guava.version>
+    <mavenPluginPluginVersion>3.6.0</mavenPluginPluginVersion>
     <m2eWorkspaceVersion>0.4.0</m2eWorkspaceVersion>
-    <pluginTestingVersion>2.9.2</pluginTestingVersion>
-    <takariLifecycleVersion>1.13.6</takariLifecycleVersion>
+    <plexusVersion>3.3.0</plexusVersion>
+    <pluginTestingVersion>2.9.3</pluginTestingVersion>
+    <takariLifecycleVersion>1.13.9</takariLifecycleVersion>
     <takari.javaSourceVersion>1.8</takari.javaSourceVersion>
   </properties>
 
@@ -99,7 +100,7 @@
                 | Please note that license-plugin is quite dumb and processes the same sources multiple times
                 | once per each level of parent/module hierarchy. This means the same excludes has to be configured
                 | on each hierarchy level too. (or hope we remember to run "mvn -N license:format", which I am sure
-                | we'll forget) 
+                | we'll forget)
                -->
               <exclude>takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/jdt/ReferenceCollection.java</exclude>
             </excludes>

--- a/takari-lifecycle-plugin-its/pom.xml
+++ b/takari-lifecycle-plugin-its/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.15</version>
+      <version>${plexusVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/AbstractIntegrationTest.java
+++ b/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/AbstractIntegrationTest.java
@@ -11,7 +11,7 @@ import io.takari.maven.testing.executor.MavenVersions;
 import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
 
 @RunWith(MavenJUnitTestRunner.class)
-@MavenVersions({"3.3.9", "3.5.0"})
+@MavenVersions({"3.6.3"})
 public abstract class AbstractIntegrationTest {
 
   @Rule

--- a/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/DeployAtEndTest.java
+++ b/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/DeployAtEndTest.java
@@ -9,7 +9,7 @@ import io.takari.maven.testing.executor.MavenExecutionResult;
 import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
 import io.takari.maven.testing.executor.MavenVersions;
 
-@MavenVersions({"3.3.9", "3.5.0"})
+@MavenVersions({"3.6.3"})
 public class DeployAtEndTest extends AbstractIntegrationTest {
 
   public DeployAtEndTest(MavenRuntimeBuilder verifierBuilder) throws Exception {

--- a/takari-lifecycle-plugin/pom.xml
+++ b/takari-lifecycle-plugin/pom.xml
@@ -21,7 +21,7 @@
 
   <!-- not inherited, IIRC -->
   <prerequisites>
-    <maven>[3.3.9,)</maven>
+    <maven>[3.6.3,)</maven>
   </prerequisites>
 
   <dependencies>
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.20</version>
+      <version>${plexusVersion}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -99,18 +99,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
       <version>${aetherVersion}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
       <version>${aetherVersion}</version>
       <scope>compile</scope>
     </dependency>
-    
+
     <!-- Build Avoidance -->
     <dependency>
       <groupId>io.takari</groupId>
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.14.0</version>
+      <version>3.20.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.compiler.apt</artifactId>
-      <version>1.3.200</version>
+      <version>1.3.800</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -143,7 +143,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.osgi</artifactId>
-      <version>3.13.0</version>
+      <version>3.15.100</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -209,7 +209,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.5.2</version>
+      <version>3.14.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -231,7 +231,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
+      <artifactId>maven-resolver-provider</artifactId>
       <version>${mavenVersion}</version>
       <scope>test</scope>
     </dependency>
@@ -250,50 +250,44 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>6.2</version>
+      <version>7.2</version>
       <scope>test</scope>
     </dependency>
     <!-- testing deploy -->
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
       <version>${aetherVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-spi</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
       <version>${aetherVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-basic</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
       <version>${aetherVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-wagon</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-wagon</artifactId>
       <version>${aetherVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-file</artifactId>
-      <version>2.6</version>
+      <version>3.3.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup</groupId>
       <artifactId>javapoet</artifactId>
-      <version>1.9.0</version>
+      <version>1.11.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -353,7 +347,7 @@
           <!-- TODO this should go to takari parent -->
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.15</version>
+          <version>1.18</version>
           <configuration>
             <signature>
               <groupId>org.codehaus.mojo.signature</groupId>

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/jdt/ClasspathEntryCache.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/jdt/ClasspathEntryCache.java
@@ -54,15 +54,19 @@ public class ClasspathEntryCache {
     long lastModified = -1;
 
     if (cacheMode == CacheMode.PESSIMISTIC) {
-      File file = location.toFile();
-      if (file.isDirectory()) {
-        // always reload dir entries
-        length = 0;
-        lastModified = System.currentTimeMillis();
-      } else {
-        // check if file has changed
-        length = file.length();
-        lastModified = file.lastModified();
+      try {
+        File file = location.toFile();
+        if (file.isDirectory()) {
+          // always reload dir entries
+          length = 0;
+          lastModified = System.currentTimeMillis();
+        } else {
+          // check if file has changed
+          length = file.length();
+          lastModified = file.lastModified();
+        }
+      } catch (UnsupportedOperationException e) {
+        // JRT Path doesn't support toFile --> JDK not expected change so don't reload
       }
     }
 

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/compile/AbstractCompileTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/compile/AbstractCompileTest.java
@@ -20,17 +20,24 @@ public abstract class AbstractCompileTest {
   public static final boolean isJava8orBetter;
   public static final boolean isJava9orBetter;
   public static final boolean isJava10orBetter;
+  public static final boolean isJava11orBetter;
 
   static {
     boolean _isJava8orBetter = false;
     boolean _isJava9orBetter = false;
     boolean _isJava10orBetter = false;
+    boolean _isJava11orBetter = false;
 
     String version = System.getProperty("java.specification.version");
     if (version != null) {
       StringTokenizer st = new StringTokenizer(version, ".");
       int major = Integer.parseInt(st.nextToken());
-      if (major >= 10) {
+      if (major >= 11) {
+        _isJava8orBetter = true;
+        _isJava9orBetter = true;
+        _isJava10orBetter = true;
+        _isJava11orBetter = true;
+      } else if (major >= 10) {
         _isJava8orBetter = true;
         _isJava9orBetter = true;
         _isJava10orBetter = true;
@@ -46,6 +53,7 @@ public abstract class AbstractCompileTest {
     isJava8orBetter = _isJava8orBetter;
     isJava9orBetter = _isJava9orBetter;
     isJava10orBetter = _isJava10orBetter;
+    isJava11orBetter = _isJava11orBetter;
   }
 
   @Rule

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/compile/CompileTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/compile/CompileTest.java
@@ -168,6 +168,13 @@ public class CompileTest extends AbstractCompileTest {
   }
 
   @Test
+  public void testBasic_java11() throws Exception {
+    assumeTrue(isJava10orBetter);
+    File basedir = compile("compile/basic", newParameter("source", "11"));
+    assertThat(new File(basedir, "target/classes/basic/Basic.class"), isVersion(55));
+  }
+
+  @Test
   public void testIncludes() throws Exception {
     Xpp3Dom includes = new Xpp3Dom("includes");
     includes.addChild(newParameter("include", "basic/Basic.java"));

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/testproperties/TestPropertiesMojoTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/testproperties/TestPropertiesMojoTest.java
@@ -83,6 +83,11 @@ public class TestPropertiesMojoTest {
       public List<MavenProject> getDownstreamProjects(MavenProject project, boolean transitive) {
         return Collections.emptyList();
       }
+
+      @Override
+      public List<MavenProject> getAllProjects() {
+        return Collections.emptyList();
+      }
     });
 
     mojos.executeMojo(session, project, newMojoExecution());


### PR DESCRIPTION
In order to run tests on Java 11 a recent Maven version is required.
This updates all versions and fixes tests to successfully pass for Java
11.

Support for older Maven versions is dropped (<= 3.6.3).