### PR TITLE
Step back to Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
   <packaging>pom</packaging>
 
   <properties>
+    <takari.javaSourceVersion>8</takari.javaSourceVersion>
     <mavenVersion>3.8.6</mavenVersion>
     <sisuVersion>0.3.5</sisuVersion>
     <sisuGuiceVersion>4.2.0</sisuGuiceVersion>


### PR DESCRIPTION
Makes Takari Lifecycle Java8 capable. But we need some agreement about this:

@jvanzyl you had this commit in 2.0.9 (that my changes to takari POM and lifecycle propagated into 2.1.0):
https://github.com/takari/takari-lifecycle/commit/e468e9a02ef9f42484f9b9831255be65969755ec

Was this the intention? As we may need latest lifecycle for polyglot that is still Java 8 (and frankly, lifecycle builds and works just nicely with Java 8).