### PR TITLE
Support parallel deploy

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/Deploy.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/Deploy.java
@@ -57,10 +57,10 @@ public class Deploy extends TakariLifecycleMojo {
 
   @Override
   public void executeMojo() throws MojoExecutionException {
-    installProject(project);
+    deployProject(project);
   }
 
-  private void installProject(MavenProject project) throws MojoExecutionException {
+  private void deployProject(MavenProject project) throws MojoExecutionException {
 
     DeployRequest deployRequest = new DeployRequest();
 


### PR DESCRIPTION
Maven Resolver 1.9.5 new feature is ability of parallel deploy, and to utilize it, **ideally** one should just "pack up all" into single DeployRequest and let resolver handle it.

Hence, this change has:
* cosmetic name changes in Deploy mojo
* batches DeployRequests (per remote repository), as currently they are created per-module. It would work like it is, but suboptimally, the ideal is to have all in there and let resolver just figure it out.

The parallel deploy is transparently available with resolver 1.9.5, (maven 3.9.1), so it will transparently become available to takari lifecycle as well, if used with Maven 3.9.1. On older version this has no any (side) effect, just that the artifacts and metadata will be deployed in-order: first ALL artifacts, then ALL metadata (in proper order).