### PR TITLE
Avoid use of deprecated ArtifactRepository to represent local repository

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/resources/AbstractProcessResourcesMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/resources/AbstractProcessResourcesMojo.java
@@ -58,11 +58,6 @@ public abstract class AbstractProcessResourcesMojo extends TakariLifecycleMojo {
   // this way resources will be properly reprocessed whenever the properties change
   //
 
-  // oddly, ${localRepository} did not work
-  @Parameter(defaultValue = "${settings.localRepository}")
-  @Incremental(configuration = Configuration.ignore)
-  private File localRepository;
-
   @Parameter(defaultValue = "${session.request.userSettingsFile}")
   @Incremental(configuration = Configuration.ignore)
   private File userSettingsFile;
@@ -96,7 +91,7 @@ public abstract class AbstractProcessResourcesMojo extends TakariLifecycleMojo {
           Map<Object, Object> properties = new HashMap<Object, Object>(this.properties);
           properties.putAll(sessionProperties); // command line parameters win over project properties
           properties.put("project", project);
-          properties.put("localRepository", localRepository);
+          properties.put("localRepository", repositorySystemSession.getLocalRepository().getBasedir().getAbsolutePath());
           properties.put("userSettingsFile", userSettingsFile);
           List<File> filters = project.getFilters().stream().map(File::new).collect(Collectors.toList());
           processor.process(sourceDirectory, targetDirectory, resource.getIncludes(), resource.getExcludes(), properties, filters, encoding, missingPropertyAction);

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/testproperties/TestPropertiesMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/testproperties/TestPropertiesMojo.java
@@ -34,6 +34,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.m2e.workspace.MutableWorkspaceState;
 
 import com.google.common.collect.ImmutableSet;
@@ -67,9 +68,6 @@ public class TestPropertiesMojo extends AbstractMojo {
 
   @Parameter(defaultValue = "${project.version}", readonly = true)
   private String version;
-
-  @Parameter(defaultValue = "${localRepository}", readonly = true)
-  private ArtifactRepository localRepository;
 
   @Parameter(defaultValue = "${session.request.userSettingsFile}", readonly = true)
   private File userSettingsFile;
@@ -105,6 +103,10 @@ public class TestPropertiesMojo extends AbstractMojo {
   @Parameter(defaultValue = "${session.projectDependencyGraph}", readonly = true)
   @Incremental(configuration = Configuration.ignore)
   private ProjectDependencyGraph reactorDependencies;
+
+  @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+  @Incremental(configuration = Configuration.ignore)
+  private RepositorySystemSession repositorySystemSession;
 
   /**
    * Sets what should be the outcome when filtering hits a missing property.
@@ -143,7 +145,7 @@ public class TestPropertiesMojo extends AbstractMojo {
       }
 
       // well-known properties, TODO introduce named constants
-      putIfAbsent(properties, "localRepository", localRepository.getBasedir());
+      putIfAbsent(properties, "localRepository", repositorySystemSession.getLocalRepository().getBasedir().getAbsolutePath());
       if (isAccessible(userSettingsFile)) {
         putIfAbsent(properties, "userSettingsFile", userSettingsFile.getAbsolutePath());
       } else {
@@ -270,7 +272,7 @@ public class TestPropertiesMojo extends AbstractMojo {
     substitutes.putAll(projectProperties);
     substitutes.putAll(sessionProperties);
     substitutes.put("project", project);
-    substitutes.put("localRepository", localRepository);
+    substitutes.put("localRepository", repositorySystemSession.getLocalRepository().getBasedir().getAbsolutePath());
     substitutes.put("userSettingsFile", userSettingsFile);
 
     for (String key : custom.stringPropertyNames()) {


### PR DESCRIPTION
As Maven 3.9.1 will warn about this expression as being deprecated. In one case repoSession was already present, just reuse it, in other case inject the repo session and use LRM from it.

See https://issues.apache.org/jira/browse/MNG-7706