### PR TITLE
Add user property to `parameters` parameter

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/AbstractCompileMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/AbstractCompileMojo.java
@@ -167,7 +167,7 @@ public abstract class AbstractCompileMojo extends AbstractMojo {
    * Set to <code>true</code> to store formal parameter names of constructors and methods in the generated class file so that the method java.lang.reflect.Executable.getParameters from the Reflection
    * API can retrieve them.
    */
-  @Parameter(defaultValue = "false")
+  @Parameter(property = "maven.compiler.parameters", defaultValue = "false")
   private boolean parameters;
 
   /**


### PR DESCRIPTION
Use the same user property `maven.compiler.parameters` as maven-compiler-plugin uses.

https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#parameters