### PR TITLE
Align with latest Maven 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
   <packaging>pom</packaging>
 
   <properties>
-    <mavenVersion>3.9.5</mavenVersion>
-    <aetherVersion>1.9.16</aetherVersion>
+    <mavenVersion>3.9.6</mavenVersion>
+    <aetherVersion>1.9.18</aetherVersion>
     <sisuVersion>0.9.0.M2</sisuVersion>
     <incrementalbuild.version>1.0.0</incrementalbuild.version>
     <guava.version>32.1.3-jre</guava.version>

--- a/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/AbstractIntegrationTest.java
+++ b/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/AbstractIntegrationTest.java
@@ -11,7 +11,7 @@ import io.takari.maven.testing.executor.MavenVersions;
 import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
 
 @RunWith(MavenJUnitTestRunner.class)
-@MavenVersions({"3.6.3"})
+@MavenVersions({"3.6.3", "3.8.8", "3.9.6"})
 public abstract class AbstractIntegrationTest {
 
   @Rule

--- a/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/CompileClasspathTest.java
+++ b/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/CompileClasspathTest.java
@@ -19,7 +19,10 @@ public class CompileClasspathTest extends AbstractIntegrationTest {
 
     MavenExecutionResult result = verifier.forProject(basedir).execute("compile");
     result.assertErrorFreeLog();
-    result.assertLogText("takari-lifecycle-plugin:" + properties.getPluginVersion() + ":compile");
+    // Logging change in 3.9 "takari-lifecycle-plugin" vs "takari-lifecycle"
+    // Maven 3.9 shows prefix, vs artifactId in previous versions
+    result.assertLogText("takari-lifecycle");
+    result.assertLogText(":" + properties.getPluginVersion() + ":compile");
     // TODO assert the class file(s) were actually created
   }
 }

--- a/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/DeployAtEndTest.java
+++ b/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/DeployAtEndTest.java
@@ -7,9 +7,7 @@ import org.junit.Test;
 
 import io.takari.maven.testing.executor.MavenExecutionResult;
 import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
-import io.takari.maven.testing.executor.MavenVersions;
 
-@MavenVersions({"3.6.3"})
 public class DeployAtEndTest extends AbstractIntegrationTest {
 
   public DeployAtEndTest(MavenRuntimeBuilder verifierBuilder) throws Exception {

--- a/takari-lifecycle-plugin/pom.xml
+++ b/takari-lifecycle-plugin/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-classworlds</artifactId>
-      <version>2.7.0</version>
+      <version>2.8.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -177,7 +177,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
     <!-- Dependency -->
     <dependency>
@@ -195,7 +195,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
-      <version>1.3</version>
+      <version>1.4.0</version>
     </dependency>
     <!-- pgp signing -->
     <dependency>
@@ -238,7 +238,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.24.2</version>
+      <version>3.25.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Changes:
* Maven 3.9.6
* Resolver 1.9.18
* plexus-classworlds 2.8.0
* commons-compress 1.25.0
* commons-exec 1.4.0
* (test) assertj-core 3.25.3
* extend ITs to run on 3.6.x, 3.8.x and 3.9.x Maven versions