### PR TITLE
Remove environment-specific manifest entries

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/jar/Jar.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/jar/Jar.java
@@ -242,8 +242,6 @@ public class Jar extends TakariLifecycleMojo {
         main.putValue("Manifest-Version", "1.0");
         main.putValue("Archiver-Version", "Provisio Archiver");
         main.putValue("Created-By", "Takari Inc.");
-        main.putValue("Built-By", System.getProperty("user.name"));
-        main.putValue("Build-Jdk", System.getProperty("java.version"));
         main.putValue("Specification-Title", project.getArtifactId());
         main.putValue("Specification-Version", project.getVersion());
         main.putValue("Implementation-Title", project.getArtifactId());

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/jar/JarTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/jar/JarTest.java
@@ -5,7 +5,6 @@ import static io.takari.maven.testing.TestResources.cp;
 import static io.takari.maven.testing.TestResources.create;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -105,8 +104,6 @@ public class JarTest {
             if (manifestEntry != null) {
                 InputStream is = zip1.getInputStream(manifestEntry);
                 Manifest p = new Manifest(is);
-                assertNotNull(p.getMainAttributes().getValue("Built-By"));
-                assertNotNull(p.getMainAttributes().getValue("Build-Jdk"));
                 assertEquals("1.0", p.getMainAttributes().getValue("Manifest-Version"));
                 assertEquals("test", p.getMainAttributes().getValue("Implementation-Title"));
                 assertEquals("1.0", p.getMainAttributes().getValue("Implementation-Version"));
@@ -286,8 +283,6 @@ public class JarTest {
         try (JarFile jar = new JarFile(new File(basedir, "target/test-1.0.jar"))) {
             Manifest mf = jar.getManifest();
             Attributes main = mf.getMainAttributes();
-            assertNotNull(main.getValue("Built-By"));
-            assertNotNull(main.getValue("Build-Jdk"));
             assertEquals("1.0", main.getValue("Manifest-Version"));
             assertEquals("test", main.getValue("Implementation-Title"));
             assertEquals("1.0", main.getValue("Implementation-Version"));


### PR DESCRIPTION
These make it hard to support reproducible builds