### PR TITLE
Jar entries should not depend on user TZ

### DIFF
--- a/takari-lifecycle-plugin/pom.xml
+++ b/takari-lifecycle-plugin/pom.xml
@@ -172,7 +172,7 @@
     <dependency>
       <groupId>io.takari</groupId>
       <artifactId>takari-archiver</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/jar/AggregateSource.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/jar/AggregateSource.java
@@ -32,7 +32,7 @@ class AggregateSource implements Source {
 
     @Override
     public Iterable<ExtendedArchiveEntry> entries() {
-        final Predicate<ExtendedArchiveEntry> uniquePathFilter = new Predicate<ExtendedArchiveEntry>() {
+        final Predicate<ExtendedArchiveEntry> uniquePathFilter = new Predicate<>() {
             private final Set<String> entryNames = new HashSet<>();
 
             @Override

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/jar/Jar.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/jar/Jar.java
@@ -265,7 +265,7 @@ public class Jar extends TakariLifecycleMojo {
         ByteArrayOutputStream buf = new ByteArrayOutputStream();
         manifest.write(buf);
 
-        return singleton((ExtendedArchiveEntry) new BytesEntry(MANIFEST_PATH, buf.toByteArray()));
+        return singleton(new BytesEntry(MANIFEST_PATH, buf.toByteArray()));
     }
 
     protected ExtendedArchiveEntry pomPropertiesSource(MavenProject project) throws IOException {


### PR DESCRIPTION
This is a reproducibility related fix, as previous versions of takari-lifecycle produced JARs were reproducible only in same TZ as original. Fix was to use latest takari-archiver 1.0.3 that contains the fix.

Fixes #172