### PR TITLE
Cumulative updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,4 @@ jobs:
     name: Verify
     uses: takari/takari-gh-actions/.github/workflows/ci.yml@v3
     with:
-      jdk-matrix: '[ 11,17,21 ]'
+      jdk-matrix: '[ 17,21 ]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,4 @@ jobs:
     name: Verify
     uses: takari/takari-gh-actions/.github/workflows/ci.yml@v3
     with:
-      jdk-matrix: '[ 17,21 ]'
+      jdk-matrix: '[ 17,21,24 ]'

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ To use it, declare the plugin as extension in your POM:
       <plugin>
         <groupId>io.takari.maven.plugins</groupId>
         <artifactId>takari-lifecycle-plugin</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
         <extensions>true</extensions>
       </plugin>
 ```
 
-Build time requirement of this project and projects using takari-lifecycle-plugin is Java11 (since 2.0.9), 
-but the project can produce even Java 7 byte code by using the "release" compiler flag.
+Build time requirement of this project and projects using takari-lifecycle-plugin is Java17 (since 2.3.0+), 
+but the project can produce even Java 8 byte code by using the "release" compiler flag.

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>takari</artifactId>
-    <version>63</version>
+    <version>64</version>
   </parent>
 
   <groupId>io.takari.maven.plugins</groupId>
@@ -24,7 +24,6 @@
 
   <modules>
     <module>takari-lifecycle-plugin</module>
-    <!-- TODO consider moving integration tests to the main module -->
     <module>takari-lifecycle-plugin-its</module>
   </modules>
 
@@ -56,7 +55,7 @@
     <pluginTestingVersion>3.0.5</pluginTestingVersion>
 
     <!-- UT and IT only! -->
-    <guava.version>33.3.1-jre</guava.version>
+    <guava.version>33.4.8-jre</guava.version>
   </properties>
 
   <build>
@@ -100,6 +99,14 @@
                 </excludes>
               </licenseSet>
             </licenseSets>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.gaul</groupId>
+          <artifactId>modernizer-maven-plugin</artifactId>
+          <configuration>
+            <!-- TODO: fix MANY violations we have -->
+            <failOnViolations>false</failOnViolations>
           </configuration>
         </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <mavenPluginPluginVersion>3.15.1</mavenPluginPluginVersion>
     <m2eWorkspaceVersion>0.4.0</m2eWorkspaceVersion>
     <plexusUtilsVersion>4.0.2</plexusUtilsVersion>
-    <plexusXmlVersion>3.0.1</plexusXmlVersion>
+    <plexusXmlVersion>3.0.2</plexusXmlVersion>
     <pluginTestingVersion>3.0.5</pluginTestingVersion>
 
     <!-- UT and IT only! -->

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>takari</artifactId>
-    <version>60</version>
+    <version>63</version>
   </parent>
 
   <groupId>io.takari.maven.plugins</groupId>
@@ -36,16 +36,27 @@
   </scm>
 
   <properties>
+    <!--
+    Note: actual runtime requirement is Java 17+ due Eclipse JDT/ECJ!
+    But, to support Maven 3.6/3.8 that use ancient Eclipse Sisu, we cannot
+    create components having bytecode newer than Java 14.
+    So we cheat here: we create components having bytecode Java 11 to make them
+    discoverable, but takari-lifecycle due dependencies is in fact Java 17+
+    -->
+    <takari.javaSourceVersion>11</takari.javaSourceVersion>
+
     <mavenVersion>3.9.9</mavenVersion>
     <aetherVersion>1.9.22</aetherVersion>
     <sisuVersion>0.9.0.M3</sisuVersion>
     <incrementalbuild.version>1.0.3</incrementalbuild.version>
-    <guava.version>33.3.0-jre</guava.version>
-    <mavenPluginPluginVersion>3.15.0</mavenPluginPluginVersion>
+    <mavenPluginPluginVersion>3.15.1</mavenPluginPluginVersion>
     <m2eWorkspaceVersion>0.4.0</m2eWorkspaceVersion>
-    <plexusUtilsVersion>4.0.1</plexusUtilsVersion>
+    <plexusUtilsVersion>4.0.2</plexusUtilsVersion>
     <plexusXmlVersion>3.0.1</plexusXmlVersion>
     <pluginTestingVersion>3.0.5</pluginTestingVersion>
+
+    <!-- UT and IT only! -->
+    <guava.version>33.3.1-jre</guava.version>
   </properties>
 
   <build>

--- a/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/AbstractIntegrationTest.java
+++ b/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/AbstractIntegrationTest.java
@@ -10,7 +10,7 @@ import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 @RunWith(MavenJUnitTestRunner.class)
-@MavenVersions({"3.6.3", "3.8.8", "3.9.6"})
+@MavenVersions({"3.6.3", "3.8.8", "3.9.9"})
 public abstract class AbstractIntegrationTest {
 
     @Rule

--- a/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/BasicTest.java
+++ b/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/BasicTest.java
@@ -3,12 +3,12 @@ package io.tesla.maven.plugins.test;
 import static io.takari.maven.testing.TestResources.assertFilesPresent;
 
 import com.google.common.io.ByteStreams;
-import com.google.common.io.Files;
 import io.takari.maven.testing.executor.MavenExecutionResult;
 import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.junit.Assert;
@@ -106,7 +106,7 @@ public class BasicTest extends AbstractIntegrationTest {
     }
 
     private String readFileUTF8(File file) throws IOException {
-        return Files.toString(file, StandardCharsets.UTF_8);
+        return Files.readString(file.toPath(), StandardCharsets.UTF_8);
     }
 
     @Test

--- a/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/FilteringResourcesTest.java
+++ b/takari-lifecycle-plugin-its/src/test/java/io/tesla/maven/plugins/test/FilteringResourcesTest.java
@@ -10,6 +10,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -40,7 +41,7 @@ public class FilteringResourcesTest extends AbstractIntegrationTest {
 
         Properties properties = new Properties();
         InputStream is = new FileInputStream(new File(result.getBasedir(), "target/classes/filtered.properties"));
-        Reader reader = new InputStreamReader(is, "UTF-8");
+        Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8);
         try {
             properties.load(reader);
         } finally {

--- a/takari-lifecycle-plugin/pom.xml
+++ b/takari-lifecycle-plugin/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-java</artifactId>
-      <version>1.2.0</version>
+      <version>1.3.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.33.0</version>
+      <version>3.39.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>ecj</artifactId>
-      <version>3.33.0</version>
+      <version>3.39.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.osgi</artifactId>
-      <version>3.18.600</version>
+      <version>3.21.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -266,7 +266,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>9.7</version>
+      <version>9.7.1</version>
       <scope>test</scope>
     </dependency>
     <!-- testing deploy -->

--- a/takari-lifecycle-plugin/pom.xml
+++ b/takari-lifecycle-plugin/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-java</artifactId>
-      <version>1.3.0</version>
+      <version>1.5.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-classworlds</artifactId>
-      <version>2.8.0</version>
+      <version>2.9.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.39.0</version>
+      <version>3.41.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>ecj</artifactId>
-      <version>3.39.0</version>
+      <version>3.41.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.osgi</artifactId>
-      <version>3.21.0</version>
+      <version>3.23.0</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -187,7 +187,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.11.0</version>
+      <version>2.13.1</version>
     </dependency>
     <!-- Logging -->
     <dependency>
@@ -230,7 +230,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.26.3</version>
+      <version>3.27.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -266,7 +266,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>9.7.1</version>
+      <version>9.8</version>
       <scope>test</scope>
     </dependency>
     <!-- testing deploy -->

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/CompileMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/CompileMojo.java
@@ -145,7 +145,7 @@ public class CompileMojo extends AbstractCompileMojo {
         List<String> roots = project.getCompileSourceRoots();
         String root = generatedSourcesDirectory.getAbsolutePath();
         if (!roots.contains(root)) {
-            roots.add(root);
+            project.addCompileSourceRoot(root);
         }
     }
 

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/TestCompileMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/TestCompileMojo.java
@@ -133,7 +133,7 @@ public class TestCompileMojo extends AbstractCompileMojo {
         List<String> roots = project.getTestCompileSourceRoots();
         String root = generatedTestSourcesDirectory.getAbsolutePath();
         if (!roots.contains(root)) {
-            roots.add(root);
+            project.addTestCompileSourceRoot(root);
         }
     }
 

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/javac/AbstractCompilerJavac.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/javac/AbstractCompilerJavac.java
@@ -93,7 +93,7 @@ public abstract class AbstractCompilerJavac extends AbstractCompiler {
                 options.add("-proc:only");
                 break;
             case proc:
-                // this is the javac default
+                options.add("-proc:full");
                 break;
             case none:
                 options.add("-proc:none");

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/jdt/classpath/ClasspathDirectory.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/compile/jdt/classpath/ClasspathDirectory.java
@@ -35,7 +35,7 @@ public class ClasspathDirectory extends AbstractClasspathDirectory implements Cl
             if (classFile != null) {
                 try (InputStream is = Files.newInputStream(classFile)) {
                     return new NameEnvironmentAnswer(
-                            ClassFileReader.read(is, classFile.getFileName().toString(), false), accessRestriction);
+                            ClassFileReader.read(is, classFile.getFileName().toString()), accessRestriction);
                 }
             }
         } catch (ClassFormatException | IOException e) {

--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/resources/AbstractProcessResourcesMojo.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/resources/AbstractProcessResourcesMojo.java
@@ -15,6 +15,7 @@ import io.takari.resources.filtering.MissingPropertyAction;
 import io.takari.resources.filtering.ResourcesProcessor;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +71,10 @@ public abstract class AbstractProcessResourcesMojo extends TakariLifecycleMojo {
     private BuildContext context;
 
     protected void process(List<Resource> resources, File outputDirectory) throws MojoExecutionException {
+        if (encoding == null) {
+            getLog().warn("Using platform encoding to process resources, i.e. build is platform dependent!");
+        }
+        Charset charset = encoding == null ? Charset.defaultCharset() : Charset.forName(encoding);
         for (Resource resource : resources) {
             boolean filter = Boolean.parseBoolean(resource.getFiltering());
             try {
@@ -86,7 +91,7 @@ public abstract class AbstractProcessResourcesMojo extends TakariLifecycleMojo {
                     targetDirectory = outputDirectory;
                 }
                 if (filter) {
-                    Map<Object, Object> properties = new HashMap<Object, Object>(this.properties);
+                    Map<Object, Object> properties = new HashMap<>(this.properties);
                     properties.putAll(sessionProperties); // command line parameters win over project properties
                     properties.put("project", project);
                     properties.put(
@@ -105,7 +110,7 @@ public abstract class AbstractProcessResourcesMojo extends TakariLifecycleMojo {
                             resource.getExcludes(),
                             properties,
                             filters,
-                            encoding,
+                            charset,
                             missingPropertyAction);
                 } else {
                     processor.process(

--- a/takari-lifecycle-plugin/src/main/java/io/takari/resources/filtering/FilterResourcesProcessor.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/resources/filtering/FilterResourcesProcessor.java
@@ -21,7 +21,6 @@ import io.takari.incrementalbuild.Resource;
 import io.takari.incrementalbuild.ResourceMetadata;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -29,7 +28,6 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,19 +103,11 @@ class FilterResourcesProcessor extends AbstractResourceProcessor {
     }
 
     private Reader newReader(Resource<File> resource, Charset encoding) throws IOException {
-        if (encoding == null) {
-            return new FileReader(resource.getResource(), StandardCharsets.UTF_8);
-        } else {
-            return new InputStreamReader(new FileInputStream(resource.getResource()), encoding);
-        }
+        return new InputStreamReader(new FileInputStream(resource.getResource()), encoding);
     }
 
     private Writer newWriter(Output<File> output, Charset encoding) throws IOException {
-        if (encoding == null) {
-            return new OutputStreamWriter(output.newOutputStream(), StandardCharsets.UTF_8);
-        } else {
-            return new OutputStreamWriter(output.newOutputStream(), encoding);
-        }
+        return new OutputStreamWriter(output.newOutputStream(), encoding);
     }
 
     private static class NoEncodingMustacheFactory extends DefaultMustacheFactory {

--- a/takari-lifecycle-plugin/src/main/java/io/takari/resources/filtering/FilterResourcesProcessor.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/resources/filtering/FilterResourcesProcessor.java
@@ -28,6 +28,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +53,7 @@ class FilterResourcesProcessor extends AbstractResourceProcessor {
             List<String> excludes,
             Map<Object, Object> filterProperties,
             List<File> filters,
-            String encoding,
+            Charset encoding,
             MissingPropertyAction mpa)
             throws IOException {
         Map<Object, Object> effectiveProperties = new HashMap<>(filterProperties);
@@ -82,7 +84,7 @@ class FilterResourcesProcessor extends AbstractResourceProcessor {
             File sourceDirectory,
             File targetDirectory,
             Map<Object, Object> filterProperties,
-            String encoding,
+            Charset encoding,
             MissingPropertyAction mpa)
             throws IOException {
         File outputFile = relativize(sourceDirectory, targetDirectory, input.getResource());
@@ -102,17 +104,17 @@ class FilterResourcesProcessor extends AbstractResourceProcessor {
         mustache.execute(writer, properties).close();
     }
 
-    private Reader newReader(Resource<File> resource, String encoding) throws IOException {
+    private Reader newReader(Resource<File> resource, Charset encoding) throws IOException {
         if (encoding == null) {
-            return new FileReader(resource.getResource());
+            return new FileReader(resource.getResource(), StandardCharsets.UTF_8);
         } else {
             return new InputStreamReader(new FileInputStream(resource.getResource()), encoding);
         }
     }
 
-    private Writer newWriter(Output<File> output, String encoding) throws IOException {
+    private Writer newWriter(Output<File> output, Charset encoding) throws IOException {
         if (encoding == null) {
-            return new OutputStreamWriter(output.newOutputStream());
+            return new OutputStreamWriter(output.newOutputStream(), StandardCharsets.UTF_8);
         } else {
             return new OutputStreamWriter(output.newOutputStream(), encoding);
         }

--- a/takari-lifecycle-plugin/src/main/java/io/takari/resources/filtering/ResourcesProcessor.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/resources/filtering/ResourcesProcessor.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +46,7 @@ public class ResourcesProcessor {
             List<String> includes,
             List<String> excludes,
             Map<Object, Object> filterProperties,
-            String encoding,
+            Charset encoding,
             MissingPropertyAction mpa)
             throws IOException {
         filterProcessor.process(
@@ -66,7 +67,7 @@ public class ResourcesProcessor {
             List<String> excludes,
             Map<Object, Object> filterProperties,
             List<File> filters,
-            String encoding,
+            Charset encoding,
             MissingPropertyAction mpa)
             throws IOException {
         filterProcessor.process(

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/compile/CompileTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/compile/CompileTest.java
@@ -13,13 +13,13 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeTrue;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import io.takari.maven.plugins.compile.javac.CompilerJavac;
 import io.takari.maven.plugins.compile.jdt.CompilerJdt;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -228,7 +228,8 @@ public class CompileTest extends AbstractCompileTest {
         // assert the compiler uses .class file when dependencySourceTypes=ignore
 
         File dependency = compile("compile/basic");
-        Files.write("corrupted", new File(dependency, "target/classes/basic/Basic.java"), Charsets.UTF_8);
+        Files.writeString(
+                new File(dependency, "target/classes/basic/Basic.java").toPath(), "corrupted", StandardCharsets.UTF_8);
         touch(new File(dependency, "target/classes/basic/Basic.java")); // javac will pick newer file by default
 
         File basedir = resources.getBasedir("compile/classpath");

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/compile/jdt/FilerImplTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/compile/jdt/FilerImplTest.java
@@ -2,7 +2,6 @@ package io.takari.maven.plugins.compile.jdt;
 
 import static io.takari.maven.testing.TestResources.create;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
 import io.takari.maven.plugins.compile.CompilerBuildContext;
 import io.takari.maven.plugins.compile.jdt.classpath.Classpath;
@@ -14,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ public class FilerImplTest {
 
     @Test
     public void testGetResource_unsupportedLocation() throws Exception {
-        EclipseFileManager fileManager = new EclipseFileManager(null, Charsets.UTF_8);
+        EclipseFileManager fileManager = new EclipseFileManager(null, StandardCharsets.UTF_8);
 
         FilerImpl filer = new FilerImpl(null /* context */, fileManager, null /* compiler */, null /* env */);
 
@@ -59,7 +59,7 @@ public class FilerImplTest {
 
     @Test
     public void testGetResource_location_classpath() throws Exception {
-        EclipseFileManager fileManager = new EclipseFileManager(null, Charsets.UTF_8);
+        EclipseFileManager fileManager = new EclipseFileManager(null, StandardCharsets.UTF_8);
 
         List<File> classpath = new ArrayList<>();
         classpath.add(new File("src/test/projects/compile-jdt-proc/getresource-location-classpath/classes"));
@@ -78,13 +78,13 @@ public class FilerImplTest {
 
     private static String toString(FileObject file) throws IOException {
         try (InputStream is = file.openInputStream()) {
-            return CharStreams.toString(new InputStreamReader(is, Charsets.UTF_8));
+            return CharStreams.toString(new InputStreamReader(is, StandardCharsets.UTF_8));
         }
     }
 
     @Test
     public void testRecreateSourceFile() throws Exception {
-        EclipseFileManager fileManager = new EclipseFileManager(null, Charsets.UTF_8);
+        EclipseFileManager fileManager = new EclipseFileManager(null, StandardCharsets.UTF_8);
 
         File outputDir = temp.newFolder();
         fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, Collections.singleton(outputDir));
@@ -105,7 +105,7 @@ public class FilerImplTest {
 
     @Test
     public void testRecreateResource() throws Exception {
-        EclipseFileManager fileManager = new EclipseFileManager(null, Charsets.UTF_8);
+        EclipseFileManager fileManager = new EclipseFileManager(null, StandardCharsets.UTF_8);
 
         File outputDir = temp.newFolder();
         fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, Collections.singleton(outputDir));
@@ -149,7 +149,7 @@ public class FilerImplTest {
         Compiler compiler =
                 new Compiler(namingEnvironment, errorHandlingPolicy, compilerOptions, requestor, problemFactory);
 
-        EclipseFileManager fileManager = new EclipseFileManager(null, Charsets.UTF_8);
+        EclipseFileManager fileManager = new EclipseFileManager(null, StandardCharsets.UTF_8);
         File outputDir = temp.newFolder();
         fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, Collections.singleton(outputDir));
 
@@ -167,7 +167,7 @@ public class FilerImplTest {
 
     @Test
     public void testResourceDoesNotExist() throws Exception {
-        EclipseFileManager fileManager = new EclipseFileManager(null, Charsets.UTF_8);
+        EclipseFileManager fileManager = new EclipseFileManager(null, StandardCharsets.UTF_8);
 
         File outputDir = temp.newFolder();
         fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, Collections.singleton(outputDir));

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/configurator/MojoConfigurationMergerTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/configurator/MojoConfigurationMergerTest.java
@@ -6,7 +6,8 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.Stack;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.descriptor.PluginDescriptorBuilder;
@@ -17,14 +18,15 @@ import org.junit.Test;
 
 public class MojoConfigurationMergerTest {
 
-    private static MojoConfigurationProcessor merger = new MojoConfigurationProcessor();
-    private static PluginDescriptorBuilder pluginDescriptorBuilder = new PluginDescriptorBuilder();
+    private static final MojoConfigurationProcessor merger = new MojoConfigurationProcessor();
+    private static final PluginDescriptorBuilder pluginDescriptorBuilder = new PluginDescriptorBuilder();
 
     @Test
     public void determineGoalFromMojoImplementation() throws Exception {
         InputStream is = getClass().getResourceAsStream("/META-INF/maven/plugin.xml");
         assertNotNull(is);
-        PluginDescriptor pluginDescriptor = pluginDescriptorBuilder.build(new InputStreamReader(is, "UTF-8"));
+        PluginDescriptor pluginDescriptor =
+                pluginDescriptorBuilder.build(new InputStreamReader(is, StandardCharsets.UTF_8));
         String goal = merger.determineGoal("io.takari.maven.plugins.jar.Jar", pluginDescriptor);
         assertEquals("We expect the goal name to be 'jar'", "jar", goal);
     }
@@ -33,7 +35,8 @@ public class MojoConfigurationMergerTest {
     public void extractionOfMojoSpecificConfigurationAndMergingwithDefaultMojoConfiguration() throws Exception {
         InputStream is = getClass().getResourceAsStream("/META-INF/maven/plugin.xml");
         assertNotNull(is);
-        PluginDescriptor pluginDescriptor = pluginDescriptorBuilder.build(new InputStreamReader(is, "UTF-8"));
+        PluginDescriptor pluginDescriptor =
+                pluginDescriptorBuilder.build(new InputStreamReader(is, StandardCharsets.UTF_8));
         String goal = merger.determineGoal("io.takari.maven.plugins.jar.Jar", pluginDescriptor);
         assertEquals("We expect the goal name to be 'jar'", "jar", goal);
         MojoDescriptor mojoDescriptor = pluginDescriptor.getMojo(goal);
@@ -92,11 +95,11 @@ public class MojoConfigurationMergerTest {
     }
 
     public class Builder {
-        private Stack<Xpp3Dom> stack;
+        private ArrayDeque<Xpp3Dom> stack;
         private Xpp3Dom configuration;
 
         public Builder(String name) {
-            stack = new Stack<Xpp3Dom>();
+            stack = new ArrayDeque<>();
             configuration = new Xpp3Dom(name);
         }
 
@@ -138,14 +141,14 @@ public class MojoConfigurationMergerTest {
         }
 
         public Xpp3Dom buildXpp3Dom() {
-            if (!stack.empty()) {
+            if (!stack.isEmpty()) {
                 throw new IllegalStateException("You have unclosed elements.");
             }
             return configuration;
         }
 
         public PlexusConfiguration buildPlexusConfiguration() {
-            if (!stack.empty()) {
+            if (!stack.isEmpty()) {
                 throw new IllegalStateException("You have unclosed elements.");
             }
             return new XmlPlexusConfiguration(configuration);

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/exportpackage/ExportPackageMojoTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/exportpackage/ExportPackageMojoTest.java
@@ -4,12 +4,12 @@ import static io.takari.maven.testing.TestResources.create;
 import static io.takari.maven.testing.TestResources.rm;
 import static io.takari.maven.testing.TestResources.touch;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import io.takari.incrementalbuild.maven.testing.IncrementalBuildRule;
 import io.takari.maven.testing.TestResources;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -100,8 +100,9 @@ public class ExportPackageMojoTest {
     }
 
     private void assertExportedPackages(File basedir, String... exportedPackages) throws IOException {
-        List<String> actual = Files.readLines(
-                new File(basedir, "target/classes/" + ExportPackageMojo.PATH_EXPORT_PACKAGE), Charsets.UTF_8);
+        List<String> actual = Files.readAllLines(
+                new File(basedir, "target/classes/" + ExportPackageMojo.PATH_EXPORT_PACKAGE).toPath(),
+                StandardCharsets.UTF_8);
         Assert.assertEquals(toString(Arrays.asList(exportedPackages)), toString(actual));
     }
 

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/resources/ResourcesTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/resources/ResourcesTest.java
@@ -6,11 +6,11 @@ import static io.takari.maven.testing.TestResources.cp;
 import static io.takari.maven.testing.TestResources.rm;
 import static org.hamcrest.CoreMatchers.containsString;
 
-import com.google.common.io.Files;
 import io.takari.incrementalbuild.maven.testing.IncrementalBuildRule;
 import io.takari.maven.testing.TestResources;
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -33,7 +33,7 @@ public class ResourcesTest {
         mojos.executeMojo(basedir, "process-resources");
         File resource = new File(basedir, "target/classes/resource.txt");
         Assert.assertTrue(resource.exists());
-        String line = Files.readFirstLine(resource, Charset.defaultCharset());
+        String line = Files.readString(resource.toPath(), Charset.defaultCharset());
         Assert.assertTrue(line.contains("resource.txt"));
     }
 
@@ -65,7 +65,8 @@ public class ResourcesTest {
         mojos.executeMojo(basedir, "process-resources");
         File resource = new File(basedir, "target/classes/resources/targetPath/resource.txt");
         Assert.assertTrue(resource.exists());
-        String line = Files.readFirstLine(resource, Charset.defaultCharset());
+        String line =
+                Files.readAllLines(resource.toPath(), Charset.defaultCharset()).get(0);
         Assert.assertTrue(line.contains("resource.txt"));
     }
 
@@ -189,8 +190,8 @@ public class ResourcesTest {
         mojos.executeMojo(basedir, "process-resources");
         mojos.assertBuildOutputs(basedir, "target/classes/resource.data");
 
-        byte[] expected = Files.toByteArray(new File(basedir, "src/main/resources/resource.data"));
-        byte[] actual = Files.toByteArray(new File(basedir, "target/classes/resource.data"));
+        byte[] expected = Files.readAllBytes(new File(basedir, "src/main/resources/resource.data").toPath());
+        byte[] actual = Files.readAllBytes(new File(basedir, "target/classes/resource.data").toPath());
         Assert.assertArrayEquals(expected, actual);
     }
 }

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/testproperties/TestPropertiesMojoTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/testproperties/TestPropertiesMojoTest.java
@@ -3,7 +3,6 @@ package io.takari.maven.plugins.testproperties;
 import static io.takari.maven.testing.TestMavenRuntime.newParameter;
 import static org.hamcrest.CoreMatchers.containsString;
 
-import com.google.common.base.Charsets;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
@@ -15,6 +14,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -241,7 +241,7 @@ public class TestPropertiesMojoTest {
         Assert.assertTrue(new File(basedir, "src/test").mkdirs());
 
         try (OutputStream os = new FileOutputStream(new File(basedir, "src/test/test.properties"))) {
-            BufferedWriter w = new BufferedWriter(new OutputStreamWriter(os, Charsets.UTF_8));
+            BufferedWriter w = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
             w.write("ga=${g:a}");
             w.newLine();
             w.write("ga_tests=${g:a:tests}");


### PR DESCRIPTION
This raises runtime requirement to Java 17, but with a twist: to support older Maven versions (3.6, 3.8) that use ancient Eclipse Sisu that support gleaning of max Java 14 bytecode (to discover components), the plugin itself remains Java 11.

Main changes in this PR:
* parent update/plugin updates/deps updates
* update JDT/ECJ to latest (requires Java 17 at runtime)
* raises lifecycle **runtime requirement to Java 17** (while it still can produce Java 8 w/ release option)
* makes lifecycle **Maven 4 compatible**
* makes lifecycle **Java 22+ (current tested w/ Java 24) compatible** (javac proc changes)