### PR TITLE
Support modern format for remote repositories

### DIFF
--- a/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/Deploy.java
+++ b/takari-lifecycle-plugin/src/main/java/io/takari/maven/plugins/Deploy.java
@@ -108,6 +108,7 @@ public class Deploy extends TakariLifecycleMojo {
     public RemoteRepository remoteRepository(MavenProject project) throws MojoExecutionException {
         if (altDeploymentRepository != null) {
             String id = null;
+            String layout = "default";
             String url = null;
             Matcher matcher = MODERN_REPOSITORY_PATTERN.matcher(altDeploymentRepository);
             if (matcher.matches()) {
@@ -117,8 +118,8 @@ public class Deploy extends TakariLifecycleMojo {
                 matcher = LEGACY_REPOSITORY_PATTERN.matcher(altDeploymentRepository);
                 if (matcher.matches()) {
                     id = matcher.group(1).trim();
+                    layout = matcher.group(2).trim();
                     url = matcher.group(3).trim();
-                    logger.warn("Using legacy syntax for repository:  use \"id::url\".");
                 }
             }
 
@@ -126,10 +127,10 @@ public class Deploy extends TakariLifecycleMojo {
                 throw new MojoExecutionException(
                         altDeploymentRepository,
                         "Invalid syntax for repository.",
-                        "Invalid syntax for alternative repository. Use \"id::url\".");
+                        "Invalid syntax for alternative repository. Use \"id::url\" or \"id::layout::url\".");
             }
 
-            RemoteRepository.Builder builder = new RemoteRepository.Builder(id, "default", url);
+            RemoteRepository.Builder builder = new RemoteRepository.Builder(id, layout, url);
 
             // Retrieve the appropriate authentication
             final AuthenticationSelector authenticationSelector = repositorySystemSession.getAuthenticationSelector();

--- a/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/install_deploy/InstallDeployTest.java
+++ b/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/install_deploy/InstallDeployTest.java
@@ -128,6 +128,43 @@ public class InstallDeployTest {
                 project,
                 "deploy",
                 newParameter(
+                        "altDeploymentRepository", "default::file://" + altDeploymentRepository.getAbsolutePath()));
+        Assert.assertTrue(new File(altDeploymentRepository, "io/takari/lifecycle/its/test/1.0/test-1.0.jar").canRead());
+        Assert.assertTrue(new File(altDeploymentRepository, "io/takari/lifecycle/its/test/1.0/test-1.0.pom").canRead());
+        Assert.assertTrue(
+                new File(altDeploymentRepository, "io/takari/lifecycle/its/test/1.0/test-1.0-sources.jar").canRead());
+        Assert.assertTrue(
+                new File(altDeploymentRepository, "io/takari/lifecycle/its/test/1.0/test-1.0-tests.jar").canRead());
+    }
+
+    @Test
+    public void testAltDeployRepositoryLegacy() throws Exception {
+        File basedir = resources.getBasedir("install-deploy/basic");
+        create(basedir, "target/classes/resource.txt", "target/test-classes/resource.txt");
+
+        File localrepo = new File(basedir, "target/localrepo");
+        Assert.assertTrue(localrepo.mkdirs());
+
+        File remoterepo = new File(basedir, "target/remoterepo");
+        Assert.assertTrue(remoterepo.mkdirs());
+
+        Properties properties = new Properties();
+        properties.put("version", "1.0");
+        properties.put("repopath", remoterepo.getCanonicalPath());
+        MavenProject project = readMavenProject(basedir, properties);
+
+        MavenSession session = newSession(project, localrepo, null);
+
+        mojos.executeMojo(session, project, "jar", newParameter("sourceJar", "true"), newParameter("testJar", "true"));
+        Assert.assertEquals(2, project.getAttachedArtifacts().size());
+
+        File altDeploymentRepository = new File(basedir, "target/altremoterepo");
+
+        mojos.executeMojo(
+                session,
+                project,
+                "deploy",
+                newParameter(
                         "altDeploymentRepository",
                         "default::default::file://" + altDeploymentRepository.getAbsolutePath()));
         Assert.assertTrue(new File(altDeploymentRepository, "io/takari/lifecycle/its/test/1.0/test-1.0.jar").canRead());


### PR DESCRIPTION
Layout is always "default", align with modern
m-deploy-p syntax.

Fixes #214